### PR TITLE
Fixed important accidental note deletion bug by slightly restructuring mouse event handling + other slight tweaks

### DIFF
--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -111,6 +111,7 @@ void NoteComponent::mouseMove(const MouseEvent &e)
     }
 
     const auto resizeEdge = this->getResizableEdge();
+
     if (this->isResizingOrScaling() ||
         (this->canResize() && (e.x >= (this->getWidth() - resizeEdge) || e.x <= resizeEdge)))
     {
@@ -118,7 +119,7 @@ void NoteComponent::mouseMove(const MouseEvent &e)
         return;
     }
 
-    this->setMouseCursor(MouseCursor::NormalCursor);
+    this->setMouseCursor(MouseCursor::UpDownLeftRightResizeCursor);   //upDownLeftRight cursor boosts click accuracy by a lot! - RPM
 }
 
 // "if ... static_cast" is here only so the macro can use the if's scope

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -262,6 +262,10 @@ void NoteComponent::mouseDown(const MouseEvent &e)
             selectedNote->startTuning();
         }
     }
+    else if (e.mods.isMiddleButtonDown())    //only tune upon ctrl + middle click drag (helps with drag panning)
+    {
+        this->roll.mouseDown(e.getEventRelativeTo(&this->roll));
+    }
 }
 
 static int lastDeltaKey = 0;
@@ -287,7 +291,7 @@ void NoteComponent::mouseDrag(const MouseEvent &e)
         return;
     }
 
-    //Bug Fifx. Moved deletion handling to NoteComponent::mouseEnter instead. 
+    //Bug Fix. Moved deletion handling to NoteComponent::mouseEnter instead.
 
     const auto &selection = this->roll.getLassoSelection();
 
@@ -493,6 +497,14 @@ void NoteComponent::mouseDrag(const MouseEvent &e)
         }
 
         SequencerOperations::getPianoSequence(selection)->changeGroup(groupBefore, groupAfter, true);
+    }
+
+    //if we're not doing any of the above then we should resort to dragging (but only if we're trying to)
+    if (e.mods.isMiddleButtonDown() && !e.mods.isAnyModifierKeyDown())
+    {
+        this->setMouseCursor(MouseCursor::DraggingHandCursor);
+        this->roll.mouseDrag(e.getEventRelativeTo(&this->roll));
+        return;
     }
 }
 

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -97,6 +97,20 @@ void NoteComponent::modifierKeysChanged(const ModifierKeys &modifiers)
     this->roll.modifierKeysChanged(modifiers);
 }
 
+void NoteComponent::mouseEnter(const MouseEvent &e) //added mouse enter event - RPM
+{
+    //notes are now drag-deleted ONLY if they are entering the note for the first time. fixes bug causing occational accidental deletion.
+    if (e.mods.isRightButtonDown() &&
+        (this->roll.getEditMode().isMode(RollEditMode::defaultMode) ||
+         this->roll.getEditMode().isMode(RollEditMode::drawMode)))
+    {
+        // see the comment above PianoRoll::startErasingEvents for
+        // the explanation of how erasing events works and why:
+        this->roll.mouseDown(e.getEventRelativeTo(&this->roll));
+        return;
+    }
+}
+
 void NoteComponent::mouseMove(const MouseEvent &e)
 {
     if (this->shouldGoQuickSelectLayerMode(e.mods))
@@ -273,12 +287,7 @@ void NoteComponent::mouseDrag(const MouseEvent &e)
         return;
     }
 
-    if (e.mods.isRightButtonDown() &&
-        this->roll.getEditMode().isMode(RollEditMode::eraseMode))
-    {
-        this->roll.mouseDrag(e.getEventRelativeTo(&this->roll));
-        return;
-    }
+    //Bug Fifx. Moved deletion handling to NoteComponent::mouseEnter instead. 
 
     const auto &selection = this->roll.getLassoSelection();
 

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -106,7 +106,7 @@ void NoteComponent::mouseEnter(const MouseEvent &e) //added mouse enter event - 
     {
         // see the comment above PianoRoll::startErasingEvents for
         // the explanation of how erasing events works and why:
-        this->roll.mouseDown(e.getEventRelativeTo(&this->roll));
+        this->roll.mouseDrag(e.getEventRelativeTo(&this->roll));
         return;
     }
 }
@@ -254,7 +254,7 @@ void NoteComponent::mouseDown(const MouseEvent &e)
             }
         }
     }
-    else if (e.mods.isMiddleButtonDown())
+    else if (e.mods.isMiddleButtonDown() && e.mods.isCtrlDown())    //only tune upon ctrl + middle click drag (helps with drag panning)
     {
         this->setMouseCursor(MouseCursor::UpDownResizeCursor);
         forEachSelectedNote(selection, selectedNote)

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.h
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.h
@@ -71,6 +71,7 @@ public:
 
     bool keyStateChanged(bool isKeyDown) override;
     void modifierKeysChanged(const ModifierKeys &modifiers) override;
+    void mouseEnter(const MouseEvent &e) override;
     void mouseMove(const MouseEvent &e) override;
     void mouseDown(const MouseEvent &e) override;
     void mouseDrag(const MouseEvent &e) override;

--- a/Source/UI/Sequencer/RollBase.cpp
+++ b/Source/UI/Sequencer/RollBase.cpp
@@ -1103,6 +1103,7 @@ void RollBase::mouseDown(const MouseEvent &e)
     }
     else if (this->isViewportDragEvent(e))
     {
+        this->setMouseCursor(MouseCursor::DraggingHandCursor);  //set drag cursor immediately upon mousing down - RPM
         this->resetDraggingAnchors();
     }
     else if (this->isViewportZoomEvent(e))


### PR DESCRIPTION
- upDownLeftRight cursor now appears when mousing over notes. I've found this makes the software greatly easier to use and causes less mental strain over time.
- Fixed a bug relating to the accidental erasure of notes upon attempting to select a track by right clicking.
- Moved note drag deletion handling to mouseEnter instead of mouseMove. 
- Note tuning with middle click now requires ctrl + drag (notes are often accidentally tuned when attempting to drag).
- drag cursor now appears immediately upon mousing down.