### PR TITLE
Tweaked Cursor and dragging mode behaviour

### DIFF
--- a/.kdev4/helio-workstation.kdev4
+++ b/.kdev4/helio-workstation.kdev4
@@ -1,0 +1,5 @@
+[Cppcheck]
+useSystemIncludes=true
+
+[Project]
+VersionControlSupport=kdevgit

--- a/Resources/colourSchemes.json
+++ b/Resources/colourSchemes.json
@@ -64,22 +64,22 @@
         }
       },
       {
-        "name": "Grayscale",
+        "name": "Grayscale",  //edited my "grayscale" to be a bit "slicker" - RPM
         "colourMap":
         {
           "text": "fff0f0f0",
-          "primaryGradientA": "ff2d2d30",
-          "primaryGradientB": "ff333333",
-          "secondaryGradientA": "ff333333",
-          "secondaryGradientB": "ff27262f",
+          "primaryGradientA": "ff242424",   //made this slightly darker - RPM
+          "primaryGradientB": "ff242424",   
+          "secondaryGradientA": "ff242424", 
+          "secondaryGradientB": "ff242424",
           "lassoFill": "25000000",
           "lassoBorder": "ffd4d4d4",
-          "whiteKey": "ff262626",
-          "blackKey": "ff212121",
-          "beat": "bf1b1923",
-          "bar": "271b1923",
-          "row": "ff1b1923",
-          "panelFill": "25535353",
+          "whiteKey": "ff1a1a1a",   //made keys sligthly darker and with a slightly reduced contrast - RPM
+          "blackKey": "ff141414",
+          "beat": "ff3d3d3d",   //made beats and bar lines a little lighter than the piano roll. easier to see and not obtrusive - RPM
+          "bar": "ff3d3d3d",
+          "row": "ff141414",
+          "panelFill": "ff252526",
           "panelBorder": "ff585858",
           "iconBase": "29ffffff",
           "iconShadow": "ff000000"

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -118,7 +118,7 @@ void NoteComponent::mouseMove(const MouseEvent &e)
         return;
     }
 
-    this->setMouseCursor(MouseCursor::NormalCursor);
+    this->setMouseCursor(MouseCursor::UpDownLeftRightResizeCursor); //improves click accuracy greatly
 }
 
 // "if ... static_cast" is here only so the macro can use the if's scope
@@ -128,6 +128,13 @@ void NoteComponent::mouseMove(const MouseEvent &e)
 
 void NoteComponent::mouseDown(const MouseEvent &e)
 {
+    //A naked middle click can only be a drag event. Immediately pass to RollBase.
+    if (e.mods.isMiddleButtonDown() && !e.mods.isAnyModifierKeyDown())
+    {
+        this->roll.mouseDown(e.getEventRelativeTo(&this->roll));
+        return;
+    }
+
     if (this->shouldGoQuickSelectLayerMode(e.mods))
     {
         this->roll.mouseDown(e.getEventRelativeTo(&this->roll));
@@ -239,7 +246,7 @@ void NoteComponent::mouseDown(const MouseEvent &e)
             }
         }
     }
-    else if (e.mods.isMiddleButtonDown())
+    else if (e.mods.isMiddleButtonDown() && e.mods.isCtrlDown())    //Tuning note now requires ctrl+middle click so as not to interfere with dragging
     {
         this->setMouseCursor(MouseCursor::UpDownResizeCursor);
         forEachSelectedNote(selection, selectedNote)
@@ -253,6 +260,13 @@ static int lastDeltaKey = 0;
 
 void NoteComponent::mouseDrag(const MouseEvent &e)
 {
+    //A naked middle click drag can only be a drag/pan event. Immediately pass to RollBase.
+    if (e.mods.isMiddleButtonDown() && !e.mods.isAnyModifierKeyDown())
+    {
+        this->roll.mouseDrag(e.getEventRelativeTo(&this->roll));
+        return;
+    }
+
     if (this->shouldGoQuickSelectLayerMode(e.mods))
     {
         return;
@@ -568,6 +582,17 @@ void NoteComponent::mouseUp(const MouseEvent &e)
 
         this->setMouseCursor(MouseCursor::NormalCursor);
     }
+
+    //Set edit mode to draw upon mouseup. You would think this would
+    //best be handled from RollBase, but passing a mouseUp event to
+    //RollBase badly breaks things and causes a crash. This is because
+    //RollBase then re-triggers NoteComponent::mouseUp, which creates
+    //an infinite loop. This can be fixed by reworking the interactions
+    //between NoteComponent, PianoRoll, and RollBase, but this line
+    //sidesteps the issue.
+
+    this->roll.getEditMode().setMode(RollEditMode::drawMode);
+
 }
 
 void NoteComponent::mouseDoubleClick(const MouseEvent &e)

--- a/Source/UI/Sequencer/RollBase.cpp
+++ b/Source/UI/Sequencer/RollBase.cpp
@@ -1073,6 +1073,12 @@ void RollBase::mouseDown(const MouseEvent &e)
         return;
     }
 
+    //we want a naked middle click to always default to dragging via the rollbase
+    if (e.mods.isMiddleButtonDown() && !e.mods.isAnyModifierKeyDown())
+    {
+        this->getEditMode().setMode(RollEditMode::dragMode);
+    }
+
     if (e.mods.isRightButtonDown())
     {
         if (this->getEditMode().isMode(RollEditMode::drawMode))
@@ -1201,6 +1207,7 @@ void RollBase::mouseUp(const MouseEvent &e)
         this->deselectAll();
     }
 
+    this->getEditMode().setMode(RollEditMode::drawMode);    //rollbase defaults to drawmode upon mouseup - RPM
     this->setMouseCursor(this->project.getEditMode().getCursor());
 }
 

--- a/helio-workstation.kdev4
+++ b/helio-workstation.kdev4
@@ -1,0 +1,4 @@
+[Project]
+CreatedFrom=
+Manager=KDevGenericManager
+Name=helio-workstation


### PR DESCRIPTION
- UpDownLeftRight resize cursor appears when moving over mouse, boosting click accuracy and reducing frustration immensely.
- DraggingHandCursor now appears when drag/panning, regardless of whether you are moused over a note
- One can now drag/pan even when starting on a note
- Note tuning now requires middle click + drag instead of just middle click