### PR TITLE
Tweaked Cursor and Dragging Mode Behaviour (updated for upstream)

### DIFF
--- a/Source/UI/Sequencer/PianoRoll/PianoRoll.cpp
+++ b/Source/UI/Sequencer/PianoRoll/PianoRoll.cpp
@@ -1454,7 +1454,8 @@ void PianoRoll::insertNewNoteAt(const MouseEvent &e)
 {
     int key = 0;
     float beat = 0.f;
-    this->getRowsColsByMousePosition(e.x, e.y, key, beat);
+    int xOffset = 5;    //pretend the cursor is 5px to the right of where it actually is. massively boosts click accuracy when placing notes! - RPM
+    this->getRowsColsByMousePosition(e.x + xOffset, e.y, key, beat);
 
     auto *activeSequence = static_cast<PianoSequence *>(this->activeTrack->getSequence());
     activeSequence->checkpoint();

--- a/Source/UI/Sequencer/RollBase.cpp
+++ b/Source/UI/Sequencer/RollBase.cpp
@@ -1073,6 +1073,12 @@ void RollBase::mouseDown(const MouseEvent &e)
         return;
     }
 
+    //we want a naked middle click to always default to dragging via the rollbase
+    if (e.mods.isMiddleButtonDown() && !e.mods.isAnyModifierKeyDown())
+    {
+        this->getEditMode().setMode(RollEditMode::dragMode);
+    }
+
     if (e.mods.isRightButtonDown())
     {
         if (this->getEditMode().isMode(RollEditMode::drawMode))
@@ -1201,6 +1207,7 @@ void RollBase::mouseUp(const MouseEvent &e)
         this->deselectAll();
     }
 
+    this->getEditMode().setMode(RollEditMode::drawMode);    //rollbase defaults to drawmode upon mouseup - RPM
     this->setMouseCursor(this->project.getEditMode().getCursor());
 }
 


### PR DESCRIPTION
- UpDownLeftRight resize cursor appears when moving over mouse, boosting click accuracy and reducing frustration immensely.
- DraggingHandCursor now appears when drag/panning, regardless of whether you are moused over a note
- One can now drag/pan even when starting on a note
- Note tuning now requires middle click + drag instead of just middle click