### PR TITLE
Added mouseX offset when placing notes for better accuracy

### DIFF
--- a/Source/UI/Sequencer/PianoRoll/PianoRoll.cpp
+++ b/Source/UI/Sequencer/PianoRoll/PianoRoll.cpp
@@ -1454,7 +1454,8 @@ void PianoRoll::insertNewNoteAt(const MouseEvent &e)
 {
     int key = 0;
     float beat = 0.f;
-    this->getRowsColsByMousePosition(e.x, e.y, key, beat);
+    int xOffset = 5;
+    this->getRowsColsByMousePosition(e.x + xOffset, e.y, key, beat);    //Pretend the mouse is a little to the right of where it actually is. Boosts accuracy when placing notes - RPM
 
     auto *activeSequence = static_cast<PianoSequence *>(this->activeTrack->getSequence());
     activeSequence->checkpoint();


### PR DESCRIPTION
This fix allows users to click *on* a barline and always be certain the new note will be placed where it is intended. xOffset can be adjusted at your convenience, but it is neccecary.