### PR TITLE
Clicking on a note sets new default length and velocity

### DIFF
--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.cpp
@@ -168,6 +168,12 @@ void NoteComponent::mouseDown(const MouseEvent &e)
             this->stopSound();
         }
 
+        if (selection.getNumSelected() == 1)    //trying to do this with multiple notes selected would lead to confusing behavior - RPM
+        {
+            this->getRoll().setDefaultNoteLength(this->getLength());
+            this->getRoll().setDefaultNoteVolume(this->getVelocity());
+        }
+
         const auto resizeEdge = this->getResizableEdge();
         if (this->canResize() && e.x >= (this->getWidth() - resizeEdge))
         {


### PR DESCRIPTION
- Clicking a single note adopts that note's velocity and length as the default for future note placement