### PR TITLE
Tweaked resizableEdge Behavior

### DIFF
--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.h
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.h
@@ -172,12 +172,12 @@ private:
     static constexpr auto maxDragPolyphony = 1;
 #endif
     
-    static constexpr auto minResizableEdge = 4;
+    static constexpr auto minResizableEdge = 1;
     static constexpr auto maxResizableEdge = 12;
 
     inline int getResizableEdge() const noexcept
     {
-        return jlimit(minResizableEdge, maxResizableEdge, this->getWidth() / 8);
+        return jlimit(minResizableEdge, minResizableEdge, this->getWidth() / 8);    //changed to 'max' to 'min' because it makes more sense
     }
 
     inline bool canResize() const noexcept

--- a/Source/UI/Sequencer/PianoRoll/NoteComponent.h
+++ b/Source/UI/Sequencer/PianoRoll/NoteComponent.h
@@ -177,12 +177,12 @@ private:
 
     inline int getResizableEdge() const noexcept
     {
-        return jlimit(minResizableEdge, minResizableEdge, this->getWidth() / 8);    //changed to 'max' to 'min' because it makes more sense
+        return jlimit(minResizableEdge, maxResizableEdge, this->getWidth() / 8);
     }
 
     inline bool canResize() const noexcept
     {
-        return this->getWidth() >= (NoteComponent::maxResizableEdge * 2);
+        return this->getWidth() >= (NoteComponent::minResizableEdge * 2);   //changed to 'max' to 'min' because it makes more sense
     }
 
     inline bool isResizingOrScaling() const noexcept


### PR DESCRIPTION
- Changed maxResizableEdge to minResizableEdge when deciding whether note is resizable upon mouseOver. Resultantly, it is easier to resize small notes while the ability to resize generally doesn't suffer.