### PR TITLE
Added AppStream file (Linux)

### DIFF
--- a/Projects/Deployment/Linux/fm.helio.Workstation.metainfo.xml
+++ b/Projects/Deployment/Linux/fm.helio.Workstation.metainfo.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>fm.helio.Workstation</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <name>Helio Workstation</name>
+  <summary>Helio Project libre music composition software</summary>
+  <description>
+    <p>
+      Helio is an attempt to rethink a music sequencer to create a
+      tool that feels right. It provides a lightweight UI to help you
+      get into the zone and focus on your ideas.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://helio.fm/images/screencap1.png</image>
+      <caption>Helio main window</caption>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1" />
+  <url type="homepage">https://helio.fm/</url>
+  <releases>
+    <release date="2022-09-24" version="3.10" />
+  </releases>
+</component>

--- a/Projects/Deployment/Travis/deploy-linux.sh
+++ b/Projects/Deployment/Travis/deploy-linux.sh
@@ -35,6 +35,7 @@ cd ${TRAVIS_BUILD_DIR}/Projects
 mkdir -p ./Deployment/Linux/Debian/${ARCH}/usr/bin
 cp ./LinuxMakefile/build/helio ./Deployment/Linux/Debian/${ARCH}/usr/bin/helio
 chmod +x ./Deployment/Linux/Debian/${ARCH}/usr/bin/helio
+install -Dm644 ./Deployment/Linux/fm.helio.Workstation.metainfo.xml -t ./Deployment/Linux/Debian/${ARCH}/usr/share/metainfo
 
 dpkg-deb --build ./Deployment/Linux/Debian/${ARCH}
 scp -C ./Deployment/Linux/Debian/${ARCH}.deb ${DEPLOY_HOST}:${DEPLOY_PATH}/${RELEASE_FILENAME}.deb
@@ -46,6 +47,7 @@ cd ${TRAVIS_BUILD_DIR}/Projects
 mkdir -p ./Deployment/Linux/AppImage/${ARCH}/usr/bin
 cp ./LinuxMakefile/build/helio ./Deployment/Linux/AppImage/${ARCH}/usr/bin/helio
 chmod +x ./Deployment/Linux/AppImage/${ARCH}/usr/bin/helio
+install -Dm644 ./Deployment/Linux/fm.helio.Workstation.metainfo.xml -t ./Deployment/Linux/AppImage/${ARCH}/usr/share/metainfo
 
 unset QTDIR; unset QT_PLUGIN_PATH; unset LD_LIBRARY_PATH
 


### PR DESCRIPTION
This file is required for flatpak  (#148) but is not specific to it. It will be in the debian package and appimage (albeit I don't know how appimage work for exporting this if anything).