### PR TITLE
Allow uppercase suffix for soundfont file chooser

### DIFF
--- a/Source/Core/Audio/BuiltIn/SoundFontSynthAudioPlugin.cpp
+++ b/Source/Core/Audio/BuiltIn/SoundFontSynthAudioPlugin.cpp
@@ -143,7 +143,7 @@ public:
         if (commandId == CommandIDs::Browse)
         {
             this->fileChooser = make<FileChooser>(TRANS(I18n::Dialog::documentLoad),
-                this->lastUsedDirectory, ("*.sf2;*.sf3;*.sf4;*.sbk"), true);
+                this->lastUsedDirectory, ("*.sf2;*.sf3;*.sf4;*.sbk;*.SF2;*.SF3;*.SF4;*.FBK"), true);
 
             DocumentHelpers::showFileChooser(this->fileChooser,
                 Globals::UI::FileChooser::forFileToOpen,


### PR DESCRIPTION
Some soundfont files use uppercase extensions (SF2, SF3, SF4, SBK). Add these to the glob pattern to support case-sensitive filesystems.

In later use in SoundFontSynth.cpp, it also use
`endsWithIgnoreCase("sf2")`, so this should not be a problem.